### PR TITLE
Fix disciple month spelling

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -261,7 +261,7 @@
             ],
             disciple: [
                 "Petras", "Jacobus", "Ionus", "Andreas", "Philippos",
-                "Bartholomeus", "Matteus", "Judas", "Simonus", "Thomas"
+                "Bartholomeus", "Matthaeus", "Judas", "Simonus", "Thomas"
             ],
             seasonal: [
                 "Winterma", "Frostma", "Springma", "Bloomma", "Greemma",


### PR DESCRIPTION
## Summary
- update the disciple month name "Matthaeus" in the calendar dataset

## Testing
- `grep -n Matthaeus Augustan\ Calendar.html`


------
https://chatgpt.com/codex/tasks/task_e_68505238785c8323ab897217361fcda1