### PR TITLE
Update month selection initialization

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -298,6 +298,7 @@
             // Determine the current Augustan month
             const today = new Date();
             const currentMonth = getAugustanMonthIndex(today);
+            document.getElementById('month-select').value = currentMonth;
             
             // Add keyboard navigation
             document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- keep the month dropdown in sync with the computed current month on page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685052ed85888323be86a93d7b1a9aa3