### PR TITLE
Add Node tests for Augustan calendar utilities

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,0 +1,29 @@
+function isLeapYear(year) {
+  return (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+}
+
+function getAugustanMonthIndex(date) {
+  const gregorianDate = new Date(date);
+  const currentYear = gregorianDate.getFullYear();
+
+  const augustanYear = currentYear - (
+    gregorianDate.getMonth() === 11 &&
+    gregorianDate.getDate() >= (isLeapYear(currentYear) ? 27 : 26) ? 0 : 1
+  );
+
+  const augustanYearStart = new Date(
+    augustanYear,
+    11,
+    isLeapYear(augustanYear + 1) ? 27 : 26
+  );
+
+  const diffTime = gregorianDate - augustanYearStart;
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  return Math.min(9, Math.floor(diffDays / 40));
+}
+
+module.exports = {
+  isLeapYear,
+  getAugustanMonthIndex
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "augustan-calendar",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+const { isLeapYear, getAugustanMonthIndex } = require('../calendar');
+
+describe('isLeapYear', () => {
+  it('identifies leap years', () => {
+    assert.strictEqual(isLeapYear(2000), true);
+    assert.strictEqual(isLeapYear(2004), true);
+  });
+
+  it('identifies common years', () => {
+    assert.strictEqual(isLeapYear(1900), false);
+    assert.strictEqual(isLeapYear(2001), false);
+  });
+});
+
+describe('getAugustanMonthIndex', () => {
+  it('returns 0 for the start of the Augustan year', () => {
+    assert.strictEqual(getAugustanMonthIndex(new Date('2023-12-27')), 0);
+  });
+
+  it('returns 1 forty days after the start', () => {
+    assert.strictEqual(getAugustanMonthIndex(new Date('2024-02-05')), 1);
+  });
+
+  it('returns 7 for October 31, 2024', () => {
+    assert.strictEqual(getAugustanMonthIndex(new Date('2024-10-31')), 7);
+  });
+});


### PR DESCRIPTION
## Summary
- add `calendar.js` module exposing `isLeapYear` and `getAugustanMonthIndex`
- add Node-based tests
- include minimal `package.json` with `npm test` script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850530d011083238f9e31adc9585c52