### PR TITLE
Fix missing spacing before legend

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -224,7 +224,7 @@
         </div>
         
         <!-- Legend -->
-        <div class="bg-white rounded-xl shadow-md p-6">
+        <div class="bg-white rounded-xl shadow-md p-6 mt-8">
             <h2 class="text-xl font-bold text-gray-800 mb-4">Day Themes</h2>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <div class="flex items-center legend-entry" data-theme="day-spirit">


### PR DESCRIPTION
## Summary
- add spacing above the Day Themes legend to restore separation from the calendar

## Testing
- `echo 'No tests to run'`


------
https://chatgpt.com/codex/tasks/task_e_68505be21b688323a983f6bd2362f79c