### PR TITLE
Fix closing div in legend grid

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -243,6 +243,7 @@
                     <div class="w-6 h-6 rounded-full day-body mr-2"></div>
                     <span class="text-sm">Body</span>
                 </div>
+            </div>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- close the Day Themes grid div before the end of the `main` element

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68505bf083ac8323865a39585c4a0b10