### PR TITLE
Improve calendar accessibility

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -151,7 +151,7 @@
                         <div class="time-display text-4xl font-bold mt-2">
                             <span id="augustan-date" class="text-indigo-700"></span>
                             <span class="mx-2 text-gray-400">|</span>
-                            <span id="augustan-time" class="text-indigo-700"></span>
+                            <span id="augustan-time" class="text-indigo-700" aria-live="polite"></span>
                         </div>
                     </div>
                     <div class="mt-4 md:mt-0">
@@ -182,6 +182,7 @@
                         Today
                     </button>
                     <div class="relative">
+                        <label for="month-naming" class="sr-only">Month naming system</label>
                         <select id="month-naming" class="appearance-none bg-gray-50 border border-gray-300 text-gray-700 py-2 px-4 pr-8 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500">
                             <option value="numerical">Numerical Months</option>
                             <option value="disciple">Disciple-Based Months</option>
@@ -193,6 +194,7 @@
                     </div>
                     
                     <div class="relative">
+                        <label for="month-select" class="sr-only">Select month</label>
                         <select id="month-select" class="appearance-none bg-gray-50 border border-gray-300 text-gray-700 py-2 px-4 pr-8 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500">
                             <!-- Months will be populated by JavaScript -->
                         </select>


### PR DESCRIPTION
## Summary
- add `aria-live` to Augustan time clock for screen readers
- add screen-reader labels to month naming and month selection controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505c00e3e4832387d56a6030fe9968