### PR TITLE
Adjust highlight color on legend hover

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -116,6 +116,12 @@
             animation: fadeInHighlight 0.3s ease-out;
         }
 
+        /* Theme-specific highlight colors */
+        .day-highlight.day-spirit { outline-color: #6B8E23; }
+        .day-highlight.day-soul { outline-color: #4682B4; }
+        .day-highlight.day-mind { outline-color: #663399; }
+        .day-highlight.day-body { outline-color: #CD853F; }
+
         @keyframes fadeInHighlight {
             from { opacity: 0.5; transform: scale(0.98); }
             to { opacity: 1; transform: scale(1.02); }


### PR DESCRIPTION
## Summary
- change `day-highlight` style to support per-theme outline colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505de21a288323bfeb03b8cea2abcd