### PR TITLE
Update Augustan year boundary

### DIFF
--- a/Augustan Calendar.html
+++ b/Augustan Calendar.html
@@ -389,8 +389,8 @@
             }
             
             // Determine number of days in the month
-            const daysInMonth = (monthIndex === MONTHS_IN_YEAR - 1) 
-                ? (isLeapYear(new Date().getFullYear()) ? DAYS_IN_LAST_MONTH + 1 : DAYS_IN_LAST_MONTH) 
+            const daysInMonth = (monthIndex === MONTHS_IN_YEAR - 1)
+                ? (isLeapYear(new Date().getFullYear() + 1) ? DAYS_IN_LAST_MONTH + 1 : DAYS_IN_LAST_MONTH)
                 : DAYS_IN_FULL_MONTH;
             
             // Create day elements
@@ -499,8 +499,8 @@
             const currentYear = gregorianDate.getFullYear();
             
             // Determine Augustan year (starts in previous Gregorian year)
-            const augustanYear = currentYear - (gregorianDate.getMonth() === 11 && 
-                gregorianDate.getDate() >= (isLeapYear(currentYear) ? 27 : 26) ? 0 : 1);
+            const augustanYear = currentYear - (gregorianDate.getMonth() === 11 &&
+                gregorianDate.getDate() >= (isLeapYear(currentYear + 1) ? 27 : 26) ? 0 : 1);
             
             // Augustan year starts on Dec 26 (27 in leap years) of previous Gregorian year
             const augustanYearStart = new Date(
@@ -526,8 +526,8 @@
             const currentYear = gregorianDate.getFullYear();
             
             // Determine Augustan year (starts in previous Gregorian year)
-            const augustanYear = currentYear - (gregorianDate.getMonth() === 11 && 
-                gregorianDate.getDate() >= (isLeapYear(currentYear) ? 27 : 26) ? 0 : 1);
+            const augustanYear = currentYear - (gregorianDate.getMonth() === 11 &&
+                gregorianDate.getDate() >= (isLeapYear(currentYear + 1) ? 27 : 26) ? 0 : 1);
             
             // Augustan year starts on Dec 26 (27 in leap years) of previous Gregorian year
             const augustanYearStart = new Date(
@@ -569,8 +569,8 @@
             const currentYear = currentDate.getFullYear();
             
             // Determine Augustan year (starts in previous Gregorian year)
-            const augustanYear = currentYear - (currentDate.getMonth() === 11 && 
-                currentDate.getDate() >= (isLeapYear(currentYear) ? 27 : 26) ? 0 : 1);
+            const augustanYear = currentYear - (currentDate.getMonth() === 11 &&
+                currentDate.getDate() >= (isLeapYear(currentYear + 1) ? 27 : 26) ? 0 : 1);
             
             // Augustan year starts on Dec 26 (27 in leap years) of previous Gregorian year
             const augustanYearStart = new Date(
@@ -613,8 +613,8 @@
             const currentYear = gregorianDate.getFullYear();
             
             // Determine Augustan year (starts in previous Gregorian year)
-            const augustanYear = currentYear - (gregorianDate.getMonth() === 11 && 
-                gregorianDate.getDate() >= (isLeapYear(currentYear) ? 27 : 26) ? 0 : 1);
+            const augustanYear = currentYear - (gregorianDate.getMonth() === 11 &&
+                gregorianDate.getDate() >= (isLeapYear(currentYear + 1) ? 27 : 26) ? 0 : 1);
             
             // Augustan year starts on Dec 26 (27 in leap years) of previous Gregorian year
             const augustanYearStart = new Date(


### PR DESCRIPTION
## Summary
- adjust leap year calculation to look at the next Gregorian year
- account for leap day when rendering Thomas month

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68505e8d14008323aa787b3a577acf5a